### PR TITLE
Feature/ios ssv fix

### DIFF
--- a/ios/Sources/AdmobPlusPlugin/AdmobPlusPlugin.swift
+++ b/ios/Sources/AdmobPlusPlugin/AdmobPlusPlugin.swift
@@ -96,6 +96,7 @@ public class AdmobPlusPlugin: CAPPlugin, CAPBridgedPlugin {
         nextAdId = adId + 1
 
         let position = call.getString("position") ?? "bottom"
+        let serverSideVerificationOptions = AdMobHelper.buildServerSideVerificationOptions(from: call.getObject("serverSideVerification"))
 
         DispatchQueue.main.async { [weak self] in
             guard let self = self else {
@@ -110,9 +111,9 @@ public class AdmobPlusPlugin: CAPPlugin, CAPBridgedPlugin {
             case "InterstitialAd":
                 ad = InterstitialAd(id: adId, adUnitId: adUnitId, plugin: self)
             case "RewardedAd":
-                ad = RewardedAd(id: adId, adUnitId: adUnitId, plugin: self)
+                ad = RewardedAd(id: adId, adUnitId: adUnitId, serverSideVerificationOptions: serverSideVerificationOptions, plugin: self)
             case "RewardedInterstitialAd":
-                ad = RewardedInterstitialAd(id: adId, adUnitId: adUnitId, plugin: self)
+                ad = RewardedInterstitialAd(id: adId, adUnitId: adUnitId, serverSideVerificationOptions: serverSideVerificationOptions, plugin: self)
             default:
                 call.reject("Unsupported ad class: \(adClass)")
                 return

--- a/ios/Sources/AdmobPlusPlugin/BannerAd.swift
+++ b/ios/Sources/AdmobPlusPlugin/BannerAd.swift
@@ -48,8 +48,7 @@ class BannerAd: NSObject, Ad {
                 return
             }
 
-            guard let webView = self.plugin?.bridge?.webView,
-                  let viewController = self.plugin?.bridge?.viewController else {
+            guard let viewController = self.plugin?.bridge?.viewController else {
                 completion(AdMobError.unknown("Unable to access view hierarchy"))
                 return
             }

--- a/ios/Sources/AdmobPlusPlugin/BannerAd.swift
+++ b/ios/Sources/AdmobPlusPlugin/BannerAd.swift
@@ -48,7 +48,8 @@ class BannerAd: NSObject, Ad {
                 return
             }
 
-            guard let viewController = self.plugin?.bridge?.viewController else {
+            guard let webView = self.plugin?.bridge?.webView,
+                  let viewController = self.plugin?.bridge?.viewController else {
                 completion(AdMobError.unknown("Unable to access view hierarchy"))
                 return
             }

--- a/ios/Sources/AdmobPlusPlugin/Helper.swift
+++ b/ios/Sources/AdmobPlusPlugin/Helper.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GoogleMobileAds
+import Capacitor
 
 class AdManager {
     static let shared = AdManager()
@@ -41,6 +42,25 @@ class AdMobHelper {
     static func buildAdRequest() -> GADRequest {
         let request = GADRequest()
         return request
+    }
+
+    static func buildServerSideVerificationOptions(from object: JSObject?) -> GADServerSideVerificationOptions? {
+        guard let object = object else {
+            return nil
+        }
+
+        let options = GADServerSideVerificationOptions()
+        let userId = object["userId"] as? String
+        let customData = object["customData"] as? String
+
+        if userId == nil && customData == nil {
+            return nil
+        }
+
+        options.userIdentifier = userId
+        options.customRewardString = customData
+
+        return options
     }
 }
 

--- a/ios/Sources/AdmobPlusPlugin/RewardedAd.swift
+++ b/ios/Sources/AdmobPlusPlugin/RewardedAd.swift
@@ -6,6 +6,7 @@ import Capacitor
 class RewardedAd: NSObject, Ad {
     let id: Int
     let adUnitId: String
+    private let serverSideVerificationOptions: GADServerSideVerificationOptions?
     private var rewardedAd: GADRewardedAd?
     private weak var plugin: AdmobPlusPlugin?
 
@@ -13,9 +14,10 @@ class RewardedAd: NSObject, Ad {
         return rewardedAd != nil
     }
 
-    init(id: Int, adUnitId: String, plugin: AdmobPlusPlugin) {
+    init(id: Int, adUnitId: String, serverSideVerificationOptions: GADServerSideVerificationOptions?, plugin: AdmobPlusPlugin) {
         self.id = id
         self.adUnitId = adUnitId
+        self.serverSideVerificationOptions = serverSideVerificationOptions
         self.plugin = plugin
         super.init()
     }
@@ -36,6 +38,7 @@ class RewardedAd: NSObject, Ad {
             }
 
             self.rewardedAd = ad
+            self.rewardedAd?.serverSideVerificationOptions = self.serverSideVerificationOptions
             self.rewardedAd?.fullScreenContentDelegate = self
 
             self.plugin?.notifyListeners(Events.rewardedLoad, data: ["id": self.id])

--- a/ios/Sources/AdmobPlusPlugin/RewardedInterstitialAd.swift
+++ b/ios/Sources/AdmobPlusPlugin/RewardedInterstitialAd.swift
@@ -6,6 +6,7 @@ import Capacitor
 class RewardedInterstitialAd: NSObject, Ad {
     let id: Int
     let adUnitId: String
+    private let serverSideVerificationOptions: GADServerSideVerificationOptions?
     private var rewardedInterstitialAd: GADRewardedInterstitialAd?
     private weak var plugin: AdmobPlusPlugin?
 
@@ -13,9 +14,10 @@ class RewardedInterstitialAd: NSObject, Ad {
         return rewardedInterstitialAd != nil
     }
 
-    init(id: Int, adUnitId: String, plugin: AdmobPlusPlugin) {
+    init(id: Int, adUnitId: String, serverSideVerificationOptions: GADServerSideVerificationOptions?, plugin: AdmobPlusPlugin) {
         self.id = id
         self.adUnitId = adUnitId
+        self.serverSideVerificationOptions = serverSideVerificationOptions
         self.plugin = plugin
         super.init()
     }
@@ -36,6 +38,7 @@ class RewardedInterstitialAd: NSObject, Ad {
             }
 
             self.rewardedInterstitialAd = ad
+            self.rewardedInterstitialAd?.serverSideVerificationOptions = self.serverSideVerificationOptions
             self.rewardedInterstitialAd?.fullScreenContentDelegate = self
 
             self.plugin?.notifyListeners(Events.rewardedInterstitialLoad, data: ["id": self.id])

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -75,6 +75,42 @@ export type MobileAdOptions = {
 };
 
 /**
+ * Server-side verification options for rewarded ads.
+ *
+ * @since 1.0.0
+ */
+export type ServerSideVerificationOptions = {
+  /**
+   * A user identifier included in the server-side verification callback.
+   */
+  userId?: string;
+  /**
+   * Custom data included in the server-side verification callback.
+   */
+  customData?: string;
+};
+
+/**
+ * Options for rewarded ads.
+ *
+ * @since 1.0.0
+ */
+export type RewardedAdOptions = MobileAdOptions & {
+  /** Server-side verification options sent with rewarded callbacks. */
+  serverSideVerification?: ServerSideVerificationOptions;
+};
+
+/**
+ * Options for rewarded interstitial ads.
+ *
+ * @since 1.0.0
+ */
+export type RewardedInterstitialAdOptions = MobileAdOptions & {
+  /** Server-side verification options sent with rewarded callbacks. */
+  serverSideVerification?: ServerSideVerificationOptions;
+};
+
+/**
  * AdMob Plus Plugin interface for displaying Google AdMob ads in Capacitor apps.
  *
  * @since 1.0.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { registerPlugin } from '@capacitor/core';
 
-import type { AdMobPlusPlugin, MobileAdOptions } from './definitions';
+import type { AdMobPlusPlugin, MobileAdOptions, RewardedAdOptions, RewardedInterstitialAdOptions } from './definitions';
 
 const AdMob = registerPlugin<AdMobPlusPlugin>('AdMobPlus', {
   web: () => import('./web').then((m) => new m.AdMobPlusWeb()),
@@ -139,7 +139,7 @@ class InterstitialAd extends MobileAd {
   }
 }
 
-class RewardedAd extends MobileAd {
+class RewardedAd extends MobileAd<RewardedAdOptions> {
   static cls = 'RewardedAd';
 
   isLoaded(): Promise<boolean> {
@@ -155,7 +155,7 @@ class RewardedAd extends MobileAd {
   }
 }
 
-class RewardedInterstitialAd extends MobileAd {
+class RewardedInterstitialAd extends MobileAd<RewardedInterstitialAdOptions> {
   static cls = 'RewardedInterstitialAd';
 
   isLoaded(): Promise<boolean> {


### PR DESCRIPTION
## What
- Fix iOS rewarded and rewarded interstitial ads to forward server-side verification options
- Add TypeScript types for rewarded server-side verification options

## Why
- Android was already forwarding rewarded server-side verification data, but iOS was not
- This caused rewarded SSV callbacks on iOS to miss the userId
- The supported rewarded SSV options should also be reflected in the public TypeScript API

## How
- Read serverSideVerification from the Capacitor call in the iOS plugin
- Build GADServerSideVerificationOptions from the incoming payload
- Apply the SSV options to rewarded and rewarded interstitial ad instances before presentation
- Add RewardedAdOptions and RewardedInterstitialAdOptions types with serverSideVerification support
- Remove the unused banner variable warning in the iOS implementation

## Testing
- Ran bun run build
- Ran iOS verification build successfully
- Ran Android build successfully with local Android SDK configuration and Java 21
- Tested the plugin locally through the example app
- Verified rewarded server-side verification end to end on iOS using a real AdMob ad unit ID on a configured test device
- Confirmed userId was present in the server-side verification callback

## Not Tested
- Production traffic on non-test devices
- Additional mediation-network-specific rewarded SSV behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side verification configuration for rewarded and rewarded interstitial ads, enabling optional user identification and custom reward data parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->