### PR TITLE
[codex] migrate admob to nextgen sdk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: '21'
       - name: Build
         id: build_code
-        run: npm run verify:android
+        run: bun run verify:android
   build_ios:
     timeout-minutes: 30
     runs-on: macOS-latest

--- a/CapgoCapacitorAdmob.podspec
+++ b/CapgoCapacitorAdmob.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'Google-Mobile-Ads-SDK', '~> 11.0'
+  s.dependency 'Google-Mobile-Ads-SDK', '~> 13.1'
   s.swift_version = '5.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", from: "11.13.0")
+        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", from: "13.1.0")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 </div>
 AdMob SDK bridge for Capacitor apps
 
+Android now uses the Google Mobile Ads Next Gen SDK, and iOS is aligned to Google Mobile Ads SDK `13.1.x`, while preserving the existing Capacitor-facing API.
+
 ## Documentation
 
 The most complete doc is available here: https://capgo.app/docs/plugins/admob/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.3.0'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
-    googlePlayServicesAdsVersion = project.hasProperty('googlePlayServicesAdsVersion') ? rootProject.ext.googlePlayServicesAdsVersion : '23.0.0'
+    googleMobileAdsNextGenVersion = project.hasProperty('googleMobileAdsNextGenVersion') ? rootProject.ext.googleMobileAdsNextGenVersion : '0.25.0-beta01'
 }
 
 buildscript {
@@ -69,5 +69,5 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation "com.google.android.gms:play-services-ads:$googlePlayServicesAdsVersion"
+    implementation "com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:$googleMobileAdsNextGenVersion"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,13 +5,13 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.3.0'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
+    // Next Gen is currently published as a beta artifact; apps can override this property when pinning a newer vetted release.
     googleMobileAdsNextGenVersion = project.hasProperty('googleMobileAdsNextGenVersion') ? rootProject.ext.googleMobileAdsNextGenVersion : '0.25.0-beta01'
 }
 
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
     dependencies {
@@ -56,7 +56,6 @@ kotlin {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-all.zip
-networkTimeout=10000
+networkTimeout=60000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/src/main/kotlin/admob/plus/capacitor/AdMobPlusPlugin.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/AdMobPlusPlugin.kt
@@ -14,6 +14,7 @@ import com.getcapacitor.PluginCall
 import com.getcapacitor.PluginMethod
 import com.getcapacitor.annotation.CapacitorPlugin
 import com.google.android.libraries.ads.mobile.sdk.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.common.RequestConfiguration
 import com.google.android.libraries.ads.mobile.sdk.initialization.InitializationConfig
 import org.json.JSONException
 import org.json.JSONObject
@@ -24,6 +25,7 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
     private var helper: Helper? = null
     @Volatile
     private var mobileAdsInitialized = false
+    private var requestConfigurationOverride: RequestConfiguration? = null
 
     override fun load() {
         super.load()
@@ -62,11 +64,10 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
             return
         }
 
-        val initializationConfig = InitializationConfig.Builder(appId)
-            .setRequestConfiguration(MobileAds.getRequestConfiguration())
-            .build()
+        val initializationConfigBuilder = InitializationConfig.Builder(appId)
+        requestConfigurationOverride?.let(initializationConfigBuilder::setRequestConfiguration)
 
-        MobileAds.initialize(context, initializationConfig) {
+        MobileAds.initialize(context, initializationConfigBuilder.build()) {
             mobileAdsInitialized = true
             helper!!.configForTestLab()
             call.resolve()
@@ -85,11 +86,12 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
     @PluginMethod
     fun configRequest(call: PluginCall) {
         val ctx = ExecuteContext(call)
-        if (rejectIfNotInitialized { ctx.reject(it) }) {
-            return
+        val requestConfiguration = ctx.optRequestConfiguration()
+        requestConfigurationOverride = requestConfiguration
+        if (mobileAdsInitialized) {
+            MobileAds.setRequestConfiguration(requestConfiguration)
+            helper!!.configForTestLab()
         }
-        MobileAds.setRequestConfiguration(ctx.optRequestConfiguration())
-        helper!!.configForTestLab()
         ctx.resolve()
     }
 

--- a/android/src/main/kotlin/admob/plus/capacitor/AdMobPlusPlugin.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/AdMobPlusPlugin.kt
@@ -7,14 +7,7 @@ import admob.plus.capacitor.ads.RewardedInterstitial
 import admob.plus.core.GenericAd
 import admob.plus.core.Helper
 import android.app.Activity
-import android.app.Application
-import android.content.Context
 import android.content.pm.PackageManager
-import android.os.Build
-import android.os.Bundle
-import android.view.WindowInsets
-import android.view.WindowInsetsController
-import androidx.annotation.RequiresApi
 import com.getcapacitor.JSObject
 import com.getcapacitor.Plugin
 import com.getcapacitor.PluginCall
@@ -34,7 +27,6 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
         super.load()
         helper = Helper(this)
         ExecuteContext.plugin = this
-        applyAdMobApi35WorkaroundIfNeeded(activity.application)
     }
 
     @PluginMethod
@@ -185,54 +177,20 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
 
     private fun getAppIdFromManifest(): String? {
         return try {
-            val appContext: Context = context.applicationContext
+            val appContext = context.applicationContext
             val applicationInfo = appContext.packageManager.getApplicationInfo(
                 appContext.packageName,
                 PackageManager.GET_META_DATA
             )
-            applicationInfo.metaData?.getString("com.google.android.gms.ads.APPLICATION_ID")
+            val metaData = applicationInfo.metaData ?: return null
+            metaData.getString(ADMOB_APP_ID_KEY)?.takeIf { it.isNotBlank() }
+                ?: metaData.getInt(ADMOB_APP_ID_KEY).takeIf { it != 0 }?.let(appContext::getString)
         } catch (_: Exception) {
             null
         }
     }
 
-    private fun applyAdMobApi35WorkaroundIfNeeded(application: Application) {
-        if (Build.VERSION.SDK_INT < 35) {
-            return
-        }
-
-        application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
-            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
-
-            override fun onActivityStarted(activity: Activity) {
-                applyApi35WorkaroundToActivity(activity)
-            }
-
-            override fun onActivityResumed(activity: Activity) {
-                applyApi35WorkaroundToActivity(activity)
-            }
-
-            override fun onActivityPaused(activity: Activity) = Unit
-
-            override fun onActivityStopped(activity: Activity) = Unit
-
-            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
-
-            override fun onActivityDestroyed(activity: Activity) = Unit
-        })
-    }
-
-    @RequiresApi(Build.VERSION_CODES.S)
-    private fun applyApi35WorkaroundToActivity(activity: Activity) {
-        if (activity.javaClass.name != "com.google.android.gms.ads.AdActivity") {
-            return
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            activity.window.insetsController?.let { controller ->
-                controller.hide(WindowInsets.Type.systemBars())
-                controller.systemBarsBehavior = WindowInsetsController.BEHAVIOR_DEFAULT
-            }
-        }
+    private companion object {
+        private const val ADMOB_APP_ID_KEY = "com.google.android.gms.ads.APPLICATION_ID"
     }
 }

--- a/android/src/main/kotlin/admob/plus/capacitor/AdMobPlusPlugin.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/AdMobPlusPlugin.kt
@@ -22,6 +22,8 @@ import org.json.JSONObject
 class AdMobPlusPlugin : Plugin(), Helper.Adapter {
     private val pluginVersion = "8.0.15"
     private var helper: Helper? = null
+    @Volatile
+    private var mobileAdsInitialized = false
 
     override fun load() {
         super.load()
@@ -49,6 +51,11 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
 
     @PluginMethod
     fun start(call: PluginCall) {
+        if (mobileAdsInitialized) {
+            call.resolve()
+            return
+        }
+
         val appId = getAppIdFromManifest()
         if (appId == null) {
             call.reject("AdMob App ID missing")
@@ -60,6 +67,7 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
             .build()
 
         MobileAds.initialize(context, initializationConfig) {
+            mobileAdsInitialized = true
             helper!!.configForTestLab()
             call.resolve()
         }
@@ -68,12 +76,18 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
     @PluginMethod
     fun configure(call: PluginCall) {
         val ctx = ExecuteContext(call)
+        if (rejectIfNotInitialized { ctx.reject(it) }) {
+            return
+        }
         ctx.configure(helper!!)
     }
 
     @PluginMethod
     fun configRequest(call: PluginCall) {
         val ctx = ExecuteContext(call)
+        if (rejectIfNotInitialized { ctx.reject(it) }) {
+            return
+        }
         MobileAds.setRequestConfiguration(ctx.optRequestConfiguration())
         helper!!.configForTestLab()
         ctx.resolve()
@@ -117,6 +131,9 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
     @PluginMethod
     fun adLoad(call: PluginCall) {
         val ctx = ExecuteContext(call)
+        if (rejectIfNotInitialized { ctx.reject(it) }) {
+            return
+        }
         bridge.executeOnMainThread {
             val ad = ctx.optAdOrError() as GenericAd?
             ad?.load(ctx)
@@ -126,6 +143,9 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
     @PluginMethod
     fun adShow(call: PluginCall) {
         val ctx = ExecuteContext(call)
+        if (rejectIfNotInitialized { ctx.reject(it) }) {
+            return
+        }
         bridge.executeOnMainThread {
             val ad = ctx.optAdOrError() as GenericAd?
             if (ad != null) {
@@ -188,6 +208,14 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
         } catch (_: Exception) {
             null
         }
+    }
+
+    private fun rejectIfNotInitialized(reject: (String) -> Unit): Boolean {
+        if (mobileAdsInitialized) {
+            return false
+        }
+        reject("AdMob is not initialized. Call start() and wait for it to resolve.")
+        return true
     }
 
     private companion object {

--- a/android/src/main/kotlin/admob/plus/capacitor/AdMobPlusPlugin.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/AdMobPlusPlugin.kt
@@ -7,24 +7,34 @@ import admob.plus.capacitor.ads.RewardedInterstitial
 import admob.plus.core.GenericAd
 import admob.plus.core.Helper
 import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import android.view.WindowInsets
+import android.view.WindowInsetsController
+import androidx.annotation.RequiresApi
 import com.getcapacitor.JSObject
 import com.getcapacitor.Plugin
 import com.getcapacitor.PluginCall
 import com.getcapacitor.PluginMethod
 import com.getcapacitor.annotation.CapacitorPlugin
-import com.google.android.gms.ads.MobileAds
-import com.google.android.gms.ads.initialization.InitializationStatus
+import com.google.android.libraries.ads.mobile.sdk.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.initialization.InitializationConfig
 import org.json.JSONException
 import org.json.JSONObject
 
 @CapacitorPlugin(name = "AdMobPlus")
 class AdMobPlusPlugin : Plugin(), Helper.Adapter {
-    private val pluginVersion = "7.4.1"
+    private val pluginVersion = "8.0.15"
     private var helper: Helper? = null
+
     override fun load() {
         super.load()
         helper = Helper(this)
-        ExecuteContext.Companion.plugin = this
+        ExecuteContext.plugin = this
+        applyAdMobApi35WorkaroundIfNeeded(activity.application)
     }
 
     @PluginMethod
@@ -47,7 +57,17 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
 
     @PluginMethod
     fun start(call: PluginCall) {
-        MobileAds.initialize(context) { status: InitializationStatus? ->
+        val appId = getAppIdFromManifest()
+        if (appId == null) {
+            call.reject("AdMob App ID missing")
+            return
+        }
+
+        val initializationConfig = InitializationConfig.Builder(appId)
+            .setRequestConfiguration(MobileAds.getRequestConfiguration())
+            .build()
+
+        MobileAds.initialize(context, initializationConfig) {
             helper!!.configForTestLab()
             call.resolve()
         }
@@ -70,19 +90,23 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
     @PluginMethod
     fun adCreate(call: PluginCall) {
         val ctx = ExecuteContext(call)
-        getBridge().executeOnMainThread {
+        bridge.executeOnMainThread {
             val adClass = ctx.optString("cls")
             if (adClass == null) {
                 ctx.reject("ad cls is missing")
             } else {
-                when (adClass) {
+                val created = when (adClass) {
                     "BannerAd" -> Banner(ctx)
                     "InterstitialAd" -> Interstitial(ctx)
                     "RewardedAd" -> Rewarded(ctx)
                     "RewardedInterstitialAd" -> RewardedInterstitial(ctx)
-                    else -> ctx.reject("ad cls is not supported: $adClass")
+                    else -> null
                 }
-                ctx.resolve()
+                if (created == null) {
+                    ctx.reject("ad cls is not supported: $adClass")
+                } else {
+                    ctx.resolve()
+                }
             }
         }
     }
@@ -90,7 +114,7 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
     @PluginMethod
     fun adIsLoaded(call: PluginCall) {
         val ctx = ExecuteContext(call)
-        getBridge().executeOnMainThread {
+        bridge.executeOnMainThread {
             val ad = ctx.optAdOrError() as GenericAd?
             if (ad != null) {
                 ctx.resolve(ad.isLoaded)
@@ -101,7 +125,7 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
     @PluginMethod
     fun adLoad(call: PluginCall) {
         val ctx = ExecuteContext(call)
-        getBridge().executeOnMainThread {
+        bridge.executeOnMainThread {
             val ad = ctx.optAdOrError() as GenericAd?
             ad?.load(ctx)
         }
@@ -110,7 +134,7 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
     @PluginMethod
     fun adShow(call: PluginCall) {
         val ctx = ExecuteContext(call)
-        getBridge().executeOnMainThread {
+        bridge.executeOnMainThread {
             val ad = ctx.optAdOrError() as GenericAd?
             if (ad != null) {
                 if (ad.isLoaded) {
@@ -125,7 +149,7 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
     @PluginMethod
     fun adHide(call: PluginCall) {
         val ctx = ExecuteContext(call)
-        getBridge().executeOnMainThread {
+        bridge.executeOnMainThread {
             val ad = ctx.optAdOrError() as GenericAd?
             ad?.hide(ctx)
         }
@@ -139,11 +163,13 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
         get() = getActivity()
 
     override fun emit(eventName: String?, data: Map<String?, Any?>?) {
-        try {
-            emit(eventName, JSObject.fromJSONObject(JSONObject(data)))
-        } catch (e: JSONException) {
-            e.printStackTrace()
+        val payload = JSObject()
+        data?.forEach { (key, value) ->
+            if (key != null) {
+                payload.put(key, value)
+            }
         }
+        emit(eventName, payload)
     }
 
     @PluginMethod
@@ -154,6 +180,59 @@ class AdMobPlusPlugin : Plugin(), Helper.Adapter {
             call.resolve(ret)
         } catch (e: Exception) {
             call.reject("Could not get plugin version", e)
+        }
+    }
+
+    private fun getAppIdFromManifest(): String? {
+        return try {
+            val appContext: Context = context.applicationContext
+            val applicationInfo = appContext.packageManager.getApplicationInfo(
+                appContext.packageName,
+                PackageManager.GET_META_DATA
+            )
+            applicationInfo.metaData?.getString("com.google.android.gms.ads.APPLICATION_ID")
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun applyAdMobApi35WorkaroundIfNeeded(application: Application) {
+        if (Build.VERSION.SDK_INT < 35) {
+            return
+        }
+
+        application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+
+            override fun onActivityStarted(activity: Activity) {
+                applyApi35WorkaroundToActivity(activity)
+            }
+
+            override fun onActivityResumed(activity: Activity) {
+                applyApi35WorkaroundToActivity(activity)
+            }
+
+            override fun onActivityPaused(activity: Activity) = Unit
+
+            override fun onActivityStopped(activity: Activity) = Unit
+
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+
+            override fun onActivityDestroyed(activity: Activity) = Unit
+        })
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun applyApi35WorkaroundToActivity(activity: Activity) {
+        if (activity.javaClass.name != "com.google.android.gms.ads.AdActivity") {
+            return
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.window.insetsController?.let { controller ->
+                controller.hide(WindowInsets.Type.systemBars())
+                controller.systemBarsBehavior = WindowInsetsController.BEHAVIOR_DEFAULT
+            }
         }
     }
 }

--- a/android/src/main/kotlin/admob/plus/capacitor/ExecuteContext.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ExecuteContext.kt
@@ -64,7 +64,7 @@ class ExecuteContext internal constructor(private val call: PluginCall) : Contex
         return call.getString(name)
     }
 
-    override fun optStringList(name: String): List<String?> {
+    override fun optStringList(name: String): List<String> {
         return jsonArray2stringList(call.getArray(name))
     }
 
@@ -77,12 +77,9 @@ class ExecuteContext internal constructor(private val call: PluginCall) : Contex
     }
 
     override fun resolve(data: Boolean) {
-        try {
-            call.resolve(JSObject("true"))
-        } catch (e: JSONException) {
-            e.printStackTrace()
-            reject()
-        }
+        val result = JSObject()
+        result.put("value", data)
+        call.resolve(result)
     }
 
     override fun reject(msg: String?) {

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/Banner.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/Banner.kt
@@ -34,16 +34,17 @@ class Banner(ctx: ExecuteContext) : AdBase(ctx), GenericAd {
         get() = loaded
 
     override fun load(ctx: Context?) {
+        val requestContext = ctx ?: return
+
         if (adView == null) {
             adView = AdView(activity)
         }
 
         loaded = false
         val adSize = resolveAdSize()
-        val collapsibleAnchor = if (gravity == Gravity.TOP) "top" else "bottom"
 
         adView!!.loadAd(
-            ctx!!.optBannerAdRequest(adUnitId, adSize, collapsibleAnchor),
+            requestContext.optBannerAdRequest(adUnitId, adSize, null),
             object : AdLoadCallback<BannerAd> {
                 override fun onAdLoaded(bannerAd: BannerAd) {
                     loaded = true
@@ -65,13 +66,13 @@ class Banner(ctx: ExecuteContext) : AdBase(ctx), GenericAd {
                         }
                     }
                     emit(Generated.Events.BANNER_LOAD)
-                    ctx.resolve()
+                    requestContext.resolve()
                 }
 
                 override fun onAdFailedToLoad(loadAdError: com.google.android.libraries.ads.mobile.sdk.common.LoadAdError) {
                     loaded = false
                     emit(Generated.Events.BANNER_LOAD_FAIL, loadAdError)
-                    ctx.reject(loadAdError.message)
+                    requestContext.reject(loadAdError)
                 }
             }
         )
@@ -117,7 +118,7 @@ class Banner(ctx: ExecuteContext) : AdBase(ctx), GenericAd {
         if (parentView == null) {
             parentView = LinearLayout(webView.context)
         }
-        if (wvParentView != null && wvParentView !== parentView) {
+        if (wvParentView !== parentView) {
             if (getParentView(parentView) != null) {
                 parentView!!.removeAllViews()
                 removeFromParentView(parentView)

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/Banner.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/Banner.kt
@@ -8,63 +8,73 @@ import admob.plus.core.GenericAd
 import admob.plus.core.Helper.Companion.getParentView
 import admob.plus.core.Helper.Companion.removeFromParentView
 import android.annotation.SuppressLint
+import android.util.DisplayMetrics
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.LinearLayout
-import com.google.android.gms.ads.AdListener
-import com.google.android.gms.ads.AdSize
-import com.google.android.gms.ads.AdView
-import com.google.android.gms.ads.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.banner.AdSize
+import com.google.android.libraries.ads.mobile.sdk.banner.AdView
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
 import java.util.Objects
 
 class Banner(ctx: ExecuteContext) : AdBase(ctx), GenericAd {
-    private val adSize: AdSize
     private val gravity: Int
     private var adView: AdView? = null
+    private var loaded = false
 
     init {
-        adSize = AdSize.SMART_BANNER
         gravity = if ("top" == ctx.optPosition()) Gravity.TOP else Gravity.BOTTOM
     }
 
     override val isLoaded: Boolean
-        get() = adView != null
+        get() = loaded
 
     override fun load(ctx: Context?) {
         if (adView == null) {
             adView = AdView(activity)
-            adView!!.adUnitId = adUnitId
-            adView!!.setAdSize(adSize)
-            adView!!.adListener = object : AdListener() {
-                override fun onAdClicked() {
-                    emit(Generated.Events.BANNER_CLICK)
-                }
+        }
 
-                override fun onAdClosed() {
-                    emit(Generated.Events.BANNER_CLOSE)
-                }
+        loaded = false
+        val adSize = resolveAdSize()
+        val collapsibleAnchor = if (gravity == Gravity.TOP) "top" else "bottom"
 
-                override fun onAdFailedToLoad(error: LoadAdError) {
-                    emit(Generated.Events.BANNER_LOAD_FAIL, error)
-                }
+        adView!!.loadAd(
+            ctx!!.optBannerAdRequest(adUnitId, adSize, collapsibleAnchor),
+            object : AdLoadCallback<BannerAd> {
+                override fun onAdLoaded(bannerAd: BannerAd) {
+                    loaded = true
+                    bannerAd.adEventCallback = object : BannerAdEventCallback {
+                        override fun onAdClicked() {
+                            emit(Generated.Events.BANNER_CLICK)
+                        }
 
-                override fun onAdImpression() {
-                    emit(Generated.Events.BANNER_IMPRESSION)
-                }
+                        override fun onAdDismissedFullScreenContent() {
+                            emit(Generated.Events.BANNER_CLOSE)
+                        }
 
-                override fun onAdLoaded() {
+                        override fun onAdImpression() {
+                            emit(Generated.Events.BANNER_IMPRESSION)
+                        }
+
+                        override fun onAdShowedFullScreenContent() {
+                            emit(Generated.Events.BANNER_OPEN)
+                        }
+                    }
                     emit(Generated.Events.BANNER_LOAD)
+                    ctx.resolve()
                 }
 
-                override fun onAdOpened() {
-                    emit(Generated.Events.BANNER_OPEN)
+                override fun onAdFailedToLoad(loadAdError: com.google.android.libraries.ads.mobile.sdk.common.LoadAdError) {
+                    loaded = false
+                    emit(Generated.Events.BANNER_LOAD_FAIL, loadAdError)
+                    ctx.reject(loadAdError.message)
                 }
             }
-        }
-        adView!!.loadAd(ctx!!.optAdRequest())
-        ctx.resolve()
+        )
     }
 
     override fun show(ctx: Context?) {
@@ -73,7 +83,6 @@ class Banner(ctx: ExecuteContext) : AdBase(ctx), GenericAd {
         if (getParentView(adView) == null) {
             addBannerView(ExecuteContext.Companion.plugin, adView)
         } else if (adView!!.visibility == View.GONE) {
-            adView!!.resume()
             adView!!.visibility = View.VISIBLE
         } else {
             val wvParentView = getParentView(webView)
@@ -88,7 +97,6 @@ class Banner(ctx: ExecuteContext) : AdBase(ctx), GenericAd {
 
     override fun hide(ctx: Context?) {
         if (adView != null) {
-            adView!!.pause()
             adView!!.visibility = View.GONE
         }
         ctx!!.resolve()
@@ -96,6 +104,7 @@ class Banner(ctx: ExecuteContext) : AdBase(ctx), GenericAd {
 
     override fun destroy() {
         if (adView != null) {
+            loaded = false
             adView!!.destroy()
             adView = null
         }
@@ -139,6 +148,12 @@ class Banner(ctx: ExecuteContext) : AdBase(ctx), GenericAd {
         parentView!!.bringToFront()
         parentView!!.requestLayout()
         parentView!!.requestFocus()
+    }
+
+    private fun resolveAdSize(): AdSize {
+        val displayMetrics: DisplayMetrics = activity.resources.displayMetrics
+        val adWidth = (displayMetrics.widthPixels / displayMetrics.density).toInt().coerceAtLeast(1)
+        return AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(activity, adWidth)
     }
 
     companion object {

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/Interstitial.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/Interstitial.kt
@@ -4,11 +4,9 @@ import admob.plus.capacitor.ExecuteContext
 import admob.plus.capacitor.Generated
 import admob.plus.core.Context
 import admob.plus.core.GenericAd
-import com.google.android.gms.ads.AdError
-import com.google.android.gms.ads.FullScreenContentCallback
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.interstitial.InterstitialAd
-import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
 
 class Interstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     private var mAd: InterstitialAd? = null
@@ -20,20 +18,18 @@ class Interstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     override fun load(ctx: Context?) {
         clear()
         InterstitialAd.load(
-            activity,
-            adUnitId,
-            ctx!!.optAdRequest(),
-            object : InterstitialAdLoadCallback() {
+            ctx!!.optAdRequest(adUnitId),
+            object : AdLoadCallback<InterstitialAd> {
                 override fun onAdLoaded(interstitialAd: InterstitialAd) {
                     mAd = interstitialAd
-                    mAd!!.fullScreenContentCallback = object : FullScreenContentCallback() {
+                    mAd!!.adEventCallback = object : InterstitialAdEventCallback {
                         override fun onAdDismissedFullScreenContent() {
                             clear()
                             emit(Generated.Events.INTERSTITIAL_DISMISS)
                         }
 
-                        override fun onAdFailedToShowFullScreenContent(adError: AdError) {
-                            emit(Generated.Events.INTERSTITIAL_SHOW_FAIL, adError)
+                        override fun onAdFailedToShowFullScreenContent(error: com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError) {
+                            emit(Generated.Events.INTERSTITIAL_SHOW_FAIL, error)
                         }
 
                         override fun onAdShowedFullScreenContent() {
@@ -43,12 +39,16 @@ class Interstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
                         override fun onAdImpression() {
                             emit(Generated.Events.INTERSTITIAL_IMPRESSION)
                         }
+
+                        override fun onAdClicked() {
+                            emit(Generated.Events.AD_CLICK)
+                        }
                     }
                     emit(Generated.Events.INTERSTITIAL_LOAD)
                     ctx.resolve()
                 }
 
-                override fun onAdFailedToLoad(loadAdError: LoadAdError) {
+                override fun onAdFailedToLoad(loadAdError: com.google.android.libraries.ads.mobile.sdk.common.LoadAdError) {
                     clear()
                     emit(Generated.Events.INTERSTITIAL_LOAD_FAIL, loadAdError)
                     ctx.reject(loadAdError.message)
@@ -66,7 +66,6 @@ class Interstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
 
     private fun clear() {
         if (mAd != null) {
-            mAd!!.fullScreenContentCallback = null
             mAd = null
         }
     }

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/Interstitial.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/Interstitial.kt
@@ -16,9 +16,10 @@ class Interstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     }
 
     override fun load(ctx: Context?) {
+        val requestContext = ctx ?: return
         clear()
         InterstitialAd.load(
-            ctx!!.optAdRequest(adUnitId),
+            requestContext.optAdRequest(adUnitId),
             object : AdLoadCallback<InterstitialAd> {
                 override fun onAdLoaded(interstitialAd: InterstitialAd) {
                     mAd = interstitialAd
@@ -45,13 +46,13 @@ class Interstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
                         }
                     }
                     emit(Generated.Events.INTERSTITIAL_LOAD)
-                    ctx.resolve()
+                    requestContext.resolve()
                 }
 
                 override fun onAdFailedToLoad(loadAdError: com.google.android.libraries.ads.mobile.sdk.common.LoadAdError) {
                     clear()
                     emit(Generated.Events.INTERSTITIAL_LOAD_FAIL, loadAdError)
-                    ctx.reject(loadAdError.message)
+                    requestContext.reject(loadAdError)
                 }
             })
     }
@@ -61,7 +62,7 @@ class Interstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
 
     override fun show(ctx: Context?) {
         mAd!!.show(activity)
-        ctx!!.resolve()
+        ctx?.resolve()
     }
 
     private fun clear() {

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/Interstitial.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/Interstitial.kt
@@ -30,6 +30,7 @@ class Interstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
                         }
 
                         override fun onAdFailedToShowFullScreenContent(error: com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError) {
+                            clear()
                             emit(Generated.Events.INTERSTITIAL_SHOW_FAIL, error)
                         }
 
@@ -66,8 +67,6 @@ class Interstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     }
 
     private fun clear() {
-        if (mAd != null) {
-            mAd = null
-        }
+        mAd = null
     }
 }

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/Rewarded.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/Rewarded.kt
@@ -67,7 +67,11 @@ class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
         get() = mAd != null
 
     override fun show(ctx: Context?) {
-        mAd!!.show(activity) { rewardItem: RewardItem? ->
+        val ad = mAd ?: run {
+            ctx?.reject("ad is not loaded")
+            return
+        }
+        ad.show(activity) { rewardItem: RewardItem? ->
             if (rewardItem != null) {
                 emit(Generated.Events.REWARDED_REWARD, rewardItem)
             }

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/Rewarded.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/Rewarded.kt
@@ -2,6 +2,7 @@ package admob.plus.capacitor.ads
 
 import admob.plus.capacitor.ExecuteContext
 import admob.plus.capacitor.Generated
+import android.util.Log
 import admob.plus.core.Context
 import admob.plus.core.GenericAd
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
@@ -74,6 +75,8 @@ class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
         ad.show(activity) { rewardItem: RewardItem? ->
             if (rewardItem != null) {
                 emit(Generated.Events.REWARDED_REWARD, rewardItem)
+            } else {
+                Log.w("Rewarded", "Reward callback invoked with null rewardItem for adUnitId=$adUnitId")
             }
         }
         ctx?.resolve()

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/Rewarded.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/Rewarded.kt
@@ -41,6 +41,7 @@ class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
                         }
 
                         override fun onAdFailedToShowFullScreenContent(error: com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError) {
+                            clear()
                             emit(Generated.Events.REWARDED_SHOW_FAIL, error)
                         }
 
@@ -75,8 +76,6 @@ class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     }
 
     private fun clear() {
-        if (mAd != null) {
-            mAd = null
-        }
+        mAd = null
     }
 }

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/Rewarded.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/Rewarded.kt
@@ -17,19 +17,20 @@ class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     }
 
     override fun load(ctx: Context?) {
+        val requestContext = ctx ?: return
         clear()
         RewardedAd.load(
-            ctx!!.optAdRequest(adUnitId),
+            requestContext.optAdRequest(adUnitId),
             object : AdLoadCallback<RewardedAd> {
                 override fun onAdFailedToLoad(loadAdError: com.google.android.libraries.ads.mobile.sdk.common.LoadAdError) {
                     clear()
                     emit(Generated.Events.REWARDED_LOAD_FAIL, loadAdError)
-                    ctx.reject(loadAdError)
+                    requestContext.reject(loadAdError)
                 }
 
                 override fun onAdLoaded(rewardedAd: RewardedAd) {
                     mAd = rewardedAd
-                    val ssv = ctx.optServerSideVerificationOptions()
+                    val ssv = requestContext.optServerSideVerificationOptions()
                     if (ssv != null) {
                         mAd!!.setServerSideVerificationOptions(ssv)
                     }
@@ -56,7 +57,7 @@ class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
                         }
                     }
                     emit(Generated.Events.REWARDED_LOAD)
-                    ctx.resolve()
+                    requestContext.resolve()
                 }
             })
     }
@@ -66,12 +67,11 @@ class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
 
     override fun show(ctx: Context?) {
         mAd!!.show(activity) { rewardItem: RewardItem? ->
-            emit(
-                Generated.Events.REWARDED_REWARD,
-                rewardItem!!
-            )
+            if (rewardItem != null) {
+                emit(Generated.Events.REWARDED_REWARD, rewardItem)
+            }
         }
-        ctx!!.resolve()
+        ctx?.resolve()
     }
 
     private fun clear() {

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/Rewarded.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/Rewarded.kt
@@ -4,12 +4,10 @@ import admob.plus.capacitor.ExecuteContext
 import admob.plus.capacitor.Generated
 import admob.plus.core.Context
 import admob.plus.core.GenericAd
-import com.google.android.gms.ads.AdError
-import com.google.android.gms.ads.FullScreenContentCallback
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.rewarded.RewardItem
-import com.google.android.gms.ads.rewarded.RewardedAd
-import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardItem
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdEventCallback
 
 class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     private var mAd: RewardedAd? = null
@@ -21,11 +19,9 @@ class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     override fun load(ctx: Context?) {
         clear()
         RewardedAd.load(
-            activity,
-            adUnitId,
-            ctx!!.optAdRequest(),
-            object : RewardedAdLoadCallback() {
-                override fun onAdFailedToLoad(loadAdError: LoadAdError) {
+            ctx!!.optAdRequest(adUnitId),
+            object : AdLoadCallback<RewardedAd> {
+                override fun onAdFailedToLoad(loadAdError: com.google.android.libraries.ads.mobile.sdk.common.LoadAdError) {
                     clear()
                     emit(Generated.Events.REWARDED_LOAD_FAIL, loadAdError)
                     ctx.reject(loadAdError)
@@ -37,14 +33,14 @@ class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
                     if (ssv != null) {
                         mAd!!.setServerSideVerificationOptions(ssv)
                     }
-                    mAd!!.fullScreenContentCallback = object : FullScreenContentCallback() {
+                    mAd!!.adEventCallback = object : RewardedAdEventCallback {
                         override fun onAdDismissedFullScreenContent() {
                             clear()
                             emit(Generated.Events.REWARDED_DISMISS)
                         }
 
-                        override fun onAdFailedToShowFullScreenContent(adError: AdError) {
-                            emit(Generated.Events.REWARDED_SHOW_FAIL, adError)
+                        override fun onAdFailedToShowFullScreenContent(error: com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError) {
+                            emit(Generated.Events.REWARDED_SHOW_FAIL, error)
                         }
 
                         override fun onAdShowedFullScreenContent() {
@@ -53,6 +49,10 @@ class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
 
                         override fun onAdImpression() {
                             emit(Generated.Events.REWARDED_IMPRESSION)
+                        }
+
+                        override fun onAdClicked() {
+                            emit(Generated.Events.AD_CLICK)
                         }
                     }
                     emit(Generated.Events.REWARDED_LOAD)
@@ -76,7 +76,6 @@ class Rewarded(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
 
     private fun clear() {
         if (mAd != null) {
-            mAd!!.fullScreenContentCallback = null
             mAd = null
         }
     }

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/RewardedInterstitial.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/RewardedInterstitial.kt
@@ -41,6 +41,7 @@ class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
                         }
 
                         override fun onAdFailedToShowFullScreenContent(error: com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError) {
+                            clear()
                             emit(Generated.Events.REWARDED_INTERSTITIAL_SHOW_FAIL, error)
                         }
 
@@ -75,8 +76,6 @@ class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     }
 
     private fun clear() {
-        if (mAd != null) {
-            mAd = null
-        }
+        mAd = null
     }
 }

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/RewardedInterstitial.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/RewardedInterstitial.kt
@@ -2,6 +2,7 @@ package admob.plus.capacitor.ads
 
 import admob.plus.capacitor.ExecuteContext
 import admob.plus.capacitor.Generated
+import android.util.Log
 import admob.plus.core.Context
 import admob.plus.core.GenericAd
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
@@ -74,6 +75,10 @@ class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
         ad.show(activity) { rewardItem: RewardItem? ->
             if (rewardItem != null) {
                 emit(Generated.Events.REWARDED_INTERSTITIAL_REWARD, rewardItem)
+            } else {
+                Log.w(
+                    "RewardedInterstitial",
+                    "Reward callback invoked with null rewardItem for adUnitId=$adUnitId")
             }
         }
         ctx?.resolve()

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/RewardedInterstitial.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/RewardedInterstitial.kt
@@ -67,7 +67,11 @@ class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
         get() = mAd != null
 
     override fun show(ctx: Context?) {
-        mAd!!.show(activity) { rewardItem: RewardItem? ->
+        val ad = mAd ?: run {
+            ctx?.reject("ad is not loaded")
+            return
+        }
+        ad.show(activity) { rewardItem: RewardItem? ->
             if (rewardItem != null) {
                 emit(Generated.Events.REWARDED_INTERSTITIAL_REWARD, rewardItem)
             }

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/RewardedInterstitial.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/RewardedInterstitial.kt
@@ -17,19 +17,20 @@ class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     }
 
     override fun load(ctx: Context?) {
+        val requestContext = ctx ?: return
         clear()
         RewardedInterstitialAd.load(
-            ctx!!.optAdRequest(adUnitId),
+            requestContext.optAdRequest(adUnitId),
             object : AdLoadCallback<RewardedInterstitialAd> {
                 override fun onAdFailedToLoad(loadAdError: com.google.android.libraries.ads.mobile.sdk.common.LoadAdError) {
                     clear()
                     emit(Generated.Events.REWARDED_INTERSTITIAL_LOAD_FAIL, loadAdError)
-                    ctx.reject(loadAdError)
+                    requestContext.reject(loadAdError)
                 }
 
                 override fun onAdLoaded(rewardedAd: RewardedInterstitialAd) {
                     mAd = rewardedAd
-                    val ssv = ctx.optServerSideVerificationOptions()
+                    val ssv = requestContext.optServerSideVerificationOptions()
                     if (ssv != null) {
                         mAd!!.setServerSideVerificationOptions(ssv)
                     }
@@ -56,7 +57,7 @@ class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
                         }
                     }
                     emit(Generated.Events.REWARDED_INTERSTITIAL_LOAD)
-                    ctx.resolve()
+                    requestContext.resolve()
                 }
             })
     }
@@ -66,12 +67,11 @@ class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
 
     override fun show(ctx: Context?) {
         mAd!!.show(activity) { rewardItem: RewardItem? ->
-            emit(
-                Generated.Events.REWARDED_INTERSTITIAL_REWARD,
-                rewardItem!!
-            )
+            if (rewardItem != null) {
+                emit(Generated.Events.REWARDED_INTERSTITIAL_REWARD, rewardItem)
+            }
         }
-        ctx!!.resolve()
+        ctx?.resolve()
     }
 
     private fun clear() {

--- a/android/src/main/kotlin/admob/plus/capacitor/ads/RewardedInterstitial.kt
+++ b/android/src/main/kotlin/admob/plus/capacitor/ads/RewardedInterstitial.kt
@@ -4,12 +4,10 @@ import admob.plus.capacitor.ExecuteContext
 import admob.plus.capacitor.Generated
 import admob.plus.core.Context
 import admob.plus.core.GenericAd
-import com.google.android.gms.ads.AdError
-import com.google.android.gms.ads.FullScreenContentCallback
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.rewarded.RewardItem
-import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
-import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardItem
+import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd
+import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAdEventCallback
 
 class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     private var mAd: RewardedInterstitialAd? = null
@@ -21,11 +19,9 @@ class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
     override fun load(ctx: Context?) {
         clear()
         RewardedInterstitialAd.load(
-            activity,
-            adUnitId,
-            ctx!!.optAdRequest(),
-            object : RewardedInterstitialAdLoadCallback() {
-                override fun onAdFailedToLoad(loadAdError: LoadAdError) {
+            ctx!!.optAdRequest(adUnitId),
+            object : AdLoadCallback<RewardedInterstitialAd> {
+                override fun onAdFailedToLoad(loadAdError: com.google.android.libraries.ads.mobile.sdk.common.LoadAdError) {
                     clear()
                     emit(Generated.Events.REWARDED_INTERSTITIAL_LOAD_FAIL, loadAdError)
                     ctx.reject(loadAdError)
@@ -37,14 +33,14 @@ class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
                     if (ssv != null) {
                         mAd!!.setServerSideVerificationOptions(ssv)
                     }
-                    mAd!!.fullScreenContentCallback = object : FullScreenContentCallback() {
+                    mAd!!.adEventCallback = object : RewardedInterstitialAdEventCallback {
                         override fun onAdDismissedFullScreenContent() {
                             clear()
                             emit(Generated.Events.REWARDED_INTERSTITIAL_DISMISS)
                         }
 
-                        override fun onAdFailedToShowFullScreenContent(adError: AdError) {
-                            emit(Generated.Events.REWARDED_INTERSTITIAL_SHOW_FAIL, adError)
+                        override fun onAdFailedToShowFullScreenContent(error: com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError) {
+                            emit(Generated.Events.REWARDED_INTERSTITIAL_SHOW_FAIL, error)
                         }
 
                         override fun onAdShowedFullScreenContent() {
@@ -53,6 +49,10 @@ class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
 
                         override fun onAdImpression() {
                             emit(Generated.Events.REWARDED_INTERSTITIAL_IMPRESSION)
+                        }
+
+                        override fun onAdClicked() {
+                            emit(Generated.Events.AD_CLICK)
                         }
                     }
                     emit(Generated.Events.REWARDED_INTERSTITIAL_LOAD)
@@ -76,7 +76,6 @@ class RewardedInterstitial(ctx: ExecuteContext?) : AdBase(ctx), GenericAd {
 
     private fun clear() {
         if (mAd != null) {
-            mAd!!.fullScreenContentCallback = null
             mAd = null
         }
     }

--- a/android/src/main/kotlin/admob/plus/core/Ad.kt
+++ b/android/src/main/kotlin/admob/plus/core/Ad.kt
@@ -3,8 +3,9 @@ package admob.plus.core
 import android.R
 import android.app.Activity
 import android.view.ViewGroup
-import com.google.android.gms.ads.AdError
-import com.google.android.gms.ads.rewarded.RewardItem
+import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardItem
 import java.util.Objects
 
 abstract class Ad(val id: Int, val adUnitId: String) {
@@ -27,12 +28,20 @@ abstract class Ad(val id: Int, val adUnitId: String) {
     val contentView: ViewGroup?
         get() = activity.findViewById(R.id.content)
 
-    protected fun emit(eventName: String?, error: AdError) {
+    protected fun emit(eventName: String?, error: LoadAdError) {
         this.emit(eventName, object : HashMap<String?, Any?>() {
             init {
-                put("code", error.code)
+                put("code", error.code.value)
                 put("message", error.message)
-                put("cause", error.cause)
+            }
+        })
+    }
+
+    protected fun emit(eventName: String?, error: FullScreenContentError) {
+        this.emit(eventName, object : HashMap<String?, Any?>() {
+            init {
+                put("code", error.code.value)
+                put("message", error.message)
             }
         })
     }

--- a/android/src/main/kotlin/admob/plus/core/Context.kt
+++ b/android/src/main/kotlin/admob/plus/core/Context.kt
@@ -1,14 +1,14 @@
 package admob.plus.core
 
 import android.os.Bundle
-import com.google.ads.mediation.admob.AdMobAdapter
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.MobileAds
-import com.google.android.gms.ads.RequestConfiguration
-import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions
+import com.google.android.libraries.ads.mobile.sdk.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.banner.AdSize
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.RequestConfiguration
+import com.google.android.libraries.ads.mobile.sdk.rewarded.ServerSideVerificationOptions
 import org.json.JSONObject
-import java.util.Objects
 
 interface Context {
     fun has(name: String): Boolean
@@ -26,7 +26,7 @@ interface Context {
 
     fun optInt(name: String): Int?
     fun optString(name: String): String?
-    fun optStringList(name: String): List<String?>
+    fun optStringList(name: String): List<String>
     fun optObject(name: String): JSONObject?
     fun resolve()
     fun resolve(data: Boolean)
@@ -71,38 +71,43 @@ interface Context {
         return optString("position")
     }
 
-    fun optAdRequest(): AdRequest {
-        val builder = AdRequest.Builder()
-        if (has("contentUrl")) {
-            Objects.requireNonNull(optString("contentUrl"))?.let { builder.setContentUrl(it) }
-        }
+    fun optAdRequest(adUnitId: String): AdRequest {
+        val builder = AdRequest.Builder(adUnitId)
+        optString("contentUrl")?.let(builder::setContentUrl)
         val extras = Bundle()
         if (has("npa")) {
             extras.putString("npa", optString("npa"))
         }
-        return builder.addNetworkExtrasBundle(AdMobAdapter::class.java, extras).build()
+        if (!extras.isEmpty) {
+            builder.setGoogleExtrasBundle(extras)
+        }
+        return builder.build()
+    }
+
+    fun optBannerAdRequest(adUnitId: String, adSize: AdSize, collapsibleAnchor: String? = null): BannerAdRequest {
+        val builder = BannerAdRequest.Builder(adUnitId, adSize)
+        optString("contentUrl")?.let(builder::setContentUrl)
+        val extras = Bundle()
+        if (has("npa")) {
+            extras.putString("npa", optString("npa"))
+        }
+        if (collapsibleAnchor != null) {
+            extras.putString("collapsible", collapsibleAnchor)
+        }
+        if (!extras.isEmpty) {
+            builder.setGoogleExtrasBundle(extras)
+        }
+        return builder.build()
     }
 
     fun optRequestConfiguration(): RequestConfiguration {
         val builder = RequestConfiguration.Builder()
-        if (has("maxAdContentRating")) {
-            builder.setMaxAdContentRating(optString("maxAdContentRating"))
-        }
-        val tagForChildDirectedTreatment = intFromBool(
-            this, "tagForChildDirectedTreatment",
-            RequestConfiguration.TAG_FOR_CHILD_DIRECTED_TREATMENT_UNSPECIFIED,
-            RequestConfiguration.TAG_FOR_CHILD_DIRECTED_TREATMENT_TRUE,
-            RequestConfiguration.TAG_FOR_CHILD_DIRECTED_TREATMENT_FALSE
-        )
+        optMaxAdContentRating()?.let(builder::setMaxAdContentRating)
+        val tagForChildDirectedTreatment = tagForChildDirectedTreatmentFromBool(this, "tagForChildDirectedTreatment")
         if (tagForChildDirectedTreatment != null) {
             builder.setTagForChildDirectedTreatment(tagForChildDirectedTreatment)
         }
-        val tagForUnderAgeOfConsent = intFromBool(
-            this, "tagForUnderAgeOfConsent",
-            RequestConfiguration.TAG_FOR_UNDER_AGE_OF_CONSENT_UNSPECIFIED,
-            RequestConfiguration.TAG_FOR_UNDER_AGE_OF_CONSENT_TRUE,
-            RequestConfiguration.TAG_FOR_UNDER_AGE_OF_CONSENT_FALSE
-        )
+        val tagForUnderAgeOfConsent = tagForUnderAgeOfConsentFromBool(this, "tagForUnderAgeOfConsent")
         if (tagForUnderAgeOfConsent != null) {
             builder.setTagForUnderAgeOfConsent(tagForUnderAgeOfConsent)
         }
@@ -115,24 +120,30 @@ interface Context {
     fun optServerSideVerificationOptions(): ServerSideVerificationOptions? {
         val param = "serverSideVerification"
         val serverSideVerification = optObject(param) ?: return null
-        val builder = ServerSideVerificationOptions.Builder()
-        if (serverSideVerification.has("customData")) {
-            builder.setCustomData(serverSideVerification.optString("customData"))
+        val customData = if (serverSideVerification.has("customData")) {
+            serverSideVerification.optString("customData").ifBlank { null }
+        } else {
+            null
         }
-        if (serverSideVerification.has("userId")) {
-            builder.setUserId(serverSideVerification.optString("userId"))
+        val userId = if (serverSideVerification.has("userId")) {
+            serverSideVerification.optString("userId").ifBlank { null }
+        } else {
+            null
         }
-        return builder.build()
+        if (customData == null && userId == null) {
+            return null
+        }
+        return ServerSideVerificationOptions(userId ?: "", customData ?: "")
     }
 
     fun configure(helper: Helper) {
         val appMuted = optAppMuted()
         if (appMuted != null) {
-            MobileAds.setAppMuted(appMuted)
+            MobileAds.setUserMutedApp(appMuted)
         }
         val appVolume = optAppVolume()
         if (appVolume != null) {
-            MobileAds.setAppVolume(appVolume)
+            MobileAds.setUserControlledAppVolume(appVolume)
         }
         MobileAds.setRequestConfiguration(optRequestConfiguration())
         helper.configForTestLab()
@@ -140,10 +151,43 @@ interface Context {
     }
 
     companion object {
-        fun intFromBool(ctx: Context, name: String, vNull: Int, vTrue: Int, vFalse: Int): Int? {
+        private fun tagForChildDirectedTreatmentFromBool(
+            ctx: Context,
+            name: String,
+        ): RequestConfiguration.TagForChildDirectedTreatment? {
             if (!ctx.has(name)) return null
-            val v = ctx.optBoolean(name) ?: return vNull
-            return if (v) vTrue else vFalse
+            val v = ctx.optBoolean(name)
+            return when (v) {
+                true -> RequestConfiguration.TagForChildDirectedTreatment.TAG_FOR_CHILD_DIRECTED_TREATMENT_TRUE
+                false -> RequestConfiguration.TagForChildDirectedTreatment.TAG_FOR_CHILD_DIRECTED_TREATMENT_FALSE
+                null -> RequestConfiguration.TagForChildDirectedTreatment.TAG_FOR_CHILD_DIRECTED_TREATMENT_UNSPECIFIED
+            }
+        }
+
+        private fun tagForUnderAgeOfConsentFromBool(
+            ctx: Context,
+            name: String,
+        ): RequestConfiguration.TagForUnderAgeOfConsent? {
+            if (!ctx.has(name)) return null
+            val v = ctx.optBoolean(name)
+            return when (v) {
+                true -> RequestConfiguration.TagForUnderAgeOfConsent.TAG_FOR_UNDER_AGE_OF_CONSENT_TRUE
+                false -> RequestConfiguration.TagForUnderAgeOfConsent.TAG_FOR_UNDER_AGE_OF_CONSENT_FALSE
+                null -> RequestConfiguration.TagForUnderAgeOfConsent.TAG_FOR_UNDER_AGE_OF_CONSENT_UNSPECIFIED
+            }
+        }
+    }
+
+    private fun optMaxAdContentRating(): RequestConfiguration.MaxAdContentRating? {
+        if (!has("maxAdContentRating")) {
+            return null
+        }
+        return when (optString("maxAdContentRating")) {
+            "G" -> RequestConfiguration.MaxAdContentRating.MAX_AD_CONTENT_RATING_G
+            "PG" -> RequestConfiguration.MaxAdContentRating.MAX_AD_CONTENT_RATING_PG
+            "T" -> RequestConfiguration.MaxAdContentRating.MAX_AD_CONTENT_RATING_T
+            "MA" -> RequestConfiguration.MaxAdContentRating.MAX_AD_CONTENT_RATING_MA
+            else -> RequestConfiguration.MaxAdContentRating.MAX_AD_CONTENT_RATING_UNSPECIFIED
         }
     }
 }

--- a/android/src/main/kotlin/admob/plus/core/Helper.kt
+++ b/android/src/main/kotlin/admob/plus/core/Helper.kt
@@ -8,7 +8,8 @@ import android.util.DisplayMetrics
 import android.util.SparseArray
 import android.view.View
 import android.view.ViewGroup
-import com.google.android.gms.ads.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.common.RequestConfiguration
 import org.json.JSONArray
 import java.math.BigInteger
 import java.security.MessageDigest
@@ -30,14 +31,18 @@ class Helper(private val adapter: Adapter) {
             return
         }
         val config = MobileAds.getRequestConfiguration()
-        val testDeviceIds = config.testDeviceIds
+        val testDeviceIds = config.testDeviceIds.toMutableList()
         val deviceId = deviceId
         if (testDeviceIds.contains(deviceId)) {
             return
         }
         testDeviceIds.add(deviceId)
-        val builder = config.toBuilder()
-        builder.setTestDeviceIds(testDeviceIds)
+        val builder = RequestConfiguration.Builder()
+            .setTagForChildDirectedTreatment(config.tagForChildDirectedTreatment)
+            .setTagForUnderAgeOfConsent(config.tagForUnderAgeOfConsent)
+            .setMaxAdContentRating(config.maxAdContentRating)
+            .setTestDeviceIds(testDeviceIds)
+        builder.setPublisherPrivacyPersonalizationState(config.publisherPrivacyPersonalizationState)
         MobileAds.setRequestConfiguration(builder.build())
     }
 

--- a/ios/Sources/AdmobPlusPlugin/AdmobPlusPlugin.swift
+++ b/ios/Sources/AdmobPlusPlugin/AdmobPlusPlugin.swift
@@ -27,7 +27,7 @@ public class AdmobPlusPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func start(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            GADMobileAds.sharedInstance().start { _ in
+            MobileAds.shared.start { _ in
                 call.resolve()
             }
         }
@@ -38,18 +38,18 @@ public class AdmobPlusPlugin: CAPPlugin, CAPBridgedPlugin {
         let appVolume = call.getFloat("appVolume")
 
         if let muted = appMuted {
-            GADMobileAds.sharedInstance().applicationMuted = muted
+            MobileAds.shared.isApplicationMuted = muted
         }
 
         if let volume = appVolume {
-            GADMobileAds.sharedInstance().applicationVolume = volume
+            MobileAds.shared.applicationVolume = volume
         }
 
         call.resolve()
     }
 
     @objc func configRequest(_ call: CAPPluginCall) {
-        let requestConfiguration = GADMobileAds.sharedInstance().requestConfiguration
+        let requestConfiguration = MobileAds.shared.requestConfiguration
 
         if let maxAdContentRating = call.getString("maxAdContentRating") {
             switch maxAdContentRating {

--- a/ios/Sources/AdmobPlusPlugin/BannerAd.swift
+++ b/ios/Sources/AdmobPlusPlugin/BannerAd.swift
@@ -6,7 +6,7 @@ import Capacitor
 class BannerAd: NSObject, Ad {
     let id: Int
     let adUnitId: String
-    private var bannerView: GADBannerView?
+    private var bannerView: BannerView?
     private weak var plugin: AdmobPlusPlugin?
     private let position: String
     private var bannerContainer: UIView?
@@ -28,7 +28,7 @@ class BannerAd: NSObject, Ad {
             guard let self = self else { return }
 
             if self.bannerView == nil {
-                let banner = GADBannerView(adSize: GADAdSizeBanner)
+                let banner = BannerView(adSize: AdSizeBanner)
                 banner.adUnitID = self.adUnitId
                 banner.delegate = self
                 banner.rootViewController = self.plugin?.bridge?.viewController
@@ -113,31 +113,31 @@ class BannerAd: NSObject, Ad {
     }
 }
 
-extension BannerAd: GADBannerViewDelegate {
-    func bannerViewDidReceiveAd(_ bannerView: GADBannerView) {
+extension BannerAd: BannerViewDelegate {
+    func bannerViewDidReceiveAd(_ bannerView: BannerView) {
         plugin?.notifyListeners(Events.bannerLoad, data: ["id": id])
     }
 
-    func bannerView(_ bannerView: GADBannerView, didFailToReceiveAdWithError error: Error) {
+    func bannerView(_ bannerView: BannerView, didFailToReceiveAdWithError error: Error) {
         plugin?.notifyListeners(Events.bannerLoadFail, data: [
             "id": id,
             "error": error.localizedDescription
         ])
     }
 
-    func bannerViewDidRecordImpression(_ bannerView: GADBannerView) {
+    func bannerViewDidRecordImpression(_ bannerView: BannerView) {
         plugin?.notifyListeners(Events.bannerImpression, data: ["id": id])
     }
 
-    func bannerViewWillPresentScreen(_ bannerView: GADBannerView) {
+    func bannerViewWillPresentScreen(_ bannerView: BannerView) {
         plugin?.notifyListeners(Events.bannerOpen, data: ["id": id])
     }
 
-    func bannerViewWillDismissScreen(_ bannerView: GADBannerView) {
+    func bannerViewWillDismissScreen(_ bannerView: BannerView) {
         plugin?.notifyListeners(Events.bannerClose, data: ["id": id])
     }
 
-    func bannerViewDidRecordClick(_ bannerView: GADBannerView) {
+    func bannerViewDidRecordClick(_ bannerView: BannerView) {
         plugin?.notifyListeners(Events.bannerClick, data: ["id": id])
     }
 }

--- a/ios/Sources/AdmobPlusPlugin/Helper.swift
+++ b/ios/Sources/AdmobPlusPlugin/Helper.swift
@@ -39,17 +39,17 @@ extension Ad {
 }
 
 class AdMobHelper {
-    static func buildAdRequest() -> GADRequest {
-        let request = GADRequest()
+    static func buildAdRequest() -> Request {
+        let request = Request()
         return request
     }
 
-    static func buildServerSideVerificationOptions(from object: JSObject?) -> GADServerSideVerificationOptions? {
+    static func buildServerSideVerificationOptions(from object: JSObject?) -> ServerSideVerificationOptions? {
         guard let object = object else {
             return nil
         }
 
-        let options = GADServerSideVerificationOptions()
+        let options = ServerSideVerificationOptions()
         let userId = object["userId"] as? String
         let customData = object["customData"] as? String
 
@@ -58,7 +58,7 @@ class AdMobHelper {
         }
 
         options.userIdentifier = userId
-        options.customRewardString = customData
+        options.customRewardText = customData
 
         return options
     }

--- a/ios/Sources/AdmobPlusPlugin/InterstitialAd.swift
+++ b/ios/Sources/AdmobPlusPlugin/InterstitialAd.swift
@@ -6,7 +6,7 @@ import Capacitor
 class InterstitialAd: NSObject, Ad {
     let id: Int
     let adUnitId: String
-    private var interstitial: GADInterstitialAd?
+    private var interstitial: GoogleMobileAds.InterstitialAd?
     private weak var plugin: AdmobPlusPlugin?
 
     var isLoaded: Bool {
@@ -23,7 +23,7 @@ class InterstitialAd: NSObject, Ad {
     func load(completion: @escaping (Error?) -> Void) {
         let request = AdMobHelper.buildAdRequest()
 
-        GADInterstitialAd.load(withAdUnitID: adUnitId, request: request) { [weak self] ad, error in
+        GoogleMobileAds.InterstitialAd.load(with: adUnitId, request: request) { [weak self] ad, error in
             guard let self = self else { return }
 
             if let error = error {
@@ -55,7 +55,7 @@ class InterstitialAd: NSObject, Ad {
                 return
             }
 
-            interstitial.present(fromRootViewController: viewController)
+            interstitial.present(from: viewController)
             completion(nil)
         }
     }
@@ -65,27 +65,27 @@ class InterstitialAd: NSObject, Ad {
     }
 }
 
-extension InterstitialAd: GADFullScreenContentDelegate {
-    func adDidRecordImpression(_ ad: GADFullScreenPresentingAd) {
+extension InterstitialAd: FullScreenContentDelegate {
+    func adDidRecordImpression(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.interstitialImpression, data: ["id": id])
     }
 
-    func adDidRecordClick(_ ad: GADFullScreenPresentingAd) {
+    func adDidRecordClick(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.adClick, data: ["id": id])
     }
 
-    func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+    func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
         plugin?.notifyListeners(Events.interstitialShowFail, data: [
             "id": id,
             "error": error.localizedDescription
         ])
     }
 
-    func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adWillPresentFullScreenContent(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.interstitialShow, data: ["id": id])
     }
 
-    func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.interstitialDismiss, data: ["id": id])
         interstitial = nil
     }

--- a/ios/Sources/AdmobPlusPlugin/RewardedAd.swift
+++ b/ios/Sources/AdmobPlusPlugin/RewardedAd.swift
@@ -6,15 +6,15 @@ import Capacitor
 class RewardedAd: NSObject, Ad {
     let id: Int
     let adUnitId: String
-    private let serverSideVerificationOptions: GADServerSideVerificationOptions?
-    private var rewardedAd: GADRewardedAd?
+    private let serverSideVerificationOptions: ServerSideVerificationOptions?
+    private var rewardedAd: GoogleMobileAds.RewardedAd?
     private weak var plugin: AdmobPlusPlugin?
 
     var isLoaded: Bool {
         return rewardedAd != nil
     }
 
-    init(id: Int, adUnitId: String, serverSideVerificationOptions: GADServerSideVerificationOptions?, plugin: AdmobPlusPlugin) {
+    init(id: Int, adUnitId: String, serverSideVerificationOptions: ServerSideVerificationOptions?, plugin: AdmobPlusPlugin) {
         self.id = id
         self.adUnitId = adUnitId
         self.serverSideVerificationOptions = serverSideVerificationOptions
@@ -25,7 +25,7 @@ class RewardedAd: NSObject, Ad {
     func load(completion: @escaping (Error?) -> Void) {
         let request = AdMobHelper.buildAdRequest()
 
-        GADRewardedAd.load(withAdUnitID: adUnitId, request: request) { [weak self] ad, error in
+        GoogleMobileAds.RewardedAd.load(with: adUnitId, request: request) { [weak self] ad, error in
             guard let self = self else { return }
 
             if let error = error {
@@ -58,7 +58,7 @@ class RewardedAd: NSObject, Ad {
                 return
             }
 
-            rewardedAd.present(fromRootViewController: viewController) { [weak self] in
+            rewardedAd.present(from: viewController) { [weak self] in
                 guard let self = self else { return }
                 let reward = rewardedAd.adReward
                 self.plugin?.notifyListeners(Events.rewardedReward, data: [
@@ -78,27 +78,27 @@ class RewardedAd: NSObject, Ad {
     }
 }
 
-extension RewardedAd: GADFullScreenContentDelegate {
-    func adDidRecordImpression(_ ad: GADFullScreenPresentingAd) {
+extension RewardedAd: FullScreenContentDelegate {
+    func adDidRecordImpression(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.rewardedImpression, data: ["id": id])
     }
 
-    func adDidRecordClick(_ ad: GADFullScreenPresentingAd) {
+    func adDidRecordClick(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.adClick, data: ["id": id])
     }
 
-    func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+    func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
         plugin?.notifyListeners(Events.rewardedShowFail, data: [
             "id": id,
             "error": error.localizedDescription
         ])
     }
 
-    func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adWillPresentFullScreenContent(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.rewardedShow, data: ["id": id])
     }
 
-    func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.rewardedDismiss, data: ["id": id])
         rewardedAd = nil
     }

--- a/ios/Sources/AdmobPlusPlugin/RewardedInterstitialAd.swift
+++ b/ios/Sources/AdmobPlusPlugin/RewardedInterstitialAd.swift
@@ -6,15 +6,15 @@ import Capacitor
 class RewardedInterstitialAd: NSObject, Ad {
     let id: Int
     let adUnitId: String
-    private let serverSideVerificationOptions: GADServerSideVerificationOptions?
-    private var rewardedInterstitialAd: GADRewardedInterstitialAd?
+    private let serverSideVerificationOptions: ServerSideVerificationOptions?
+    private var rewardedInterstitialAd: GoogleMobileAds.RewardedInterstitialAd?
     private weak var plugin: AdmobPlusPlugin?
 
     var isLoaded: Bool {
         return rewardedInterstitialAd != nil
     }
 
-    init(id: Int, adUnitId: String, serverSideVerificationOptions: GADServerSideVerificationOptions?, plugin: AdmobPlusPlugin) {
+    init(id: Int, adUnitId: String, serverSideVerificationOptions: ServerSideVerificationOptions?, plugin: AdmobPlusPlugin) {
         self.id = id
         self.adUnitId = adUnitId
         self.serverSideVerificationOptions = serverSideVerificationOptions
@@ -25,7 +25,7 @@ class RewardedInterstitialAd: NSObject, Ad {
     func load(completion: @escaping (Error?) -> Void) {
         let request = AdMobHelper.buildAdRequest()
 
-        GADRewardedInterstitialAd.load(withAdUnitID: adUnitId, request: request) { [weak self] ad, error in
+        GoogleMobileAds.RewardedInterstitialAd.load(with: adUnitId, request: request) { [weak self] ad, error in
             guard let self = self else { return }
 
             if let error = error {
@@ -58,7 +58,7 @@ class RewardedInterstitialAd: NSObject, Ad {
                 return
             }
 
-            rewardedInterstitialAd.present(fromRootViewController: viewController) { [weak self] in
+            rewardedInterstitialAd.present(from: viewController) { [weak self] in
                 guard let self = self else { return }
                 let reward = rewardedInterstitialAd.adReward
                 self.plugin?.notifyListeners(Events.rewardedInterstitialReward, data: [
@@ -78,27 +78,27 @@ class RewardedInterstitialAd: NSObject, Ad {
     }
 }
 
-extension RewardedInterstitialAd: GADFullScreenContentDelegate {
-    func adDidRecordImpression(_ ad: GADFullScreenPresentingAd) {
+extension RewardedInterstitialAd: FullScreenContentDelegate {
+    func adDidRecordImpression(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.rewardedInterstitialImpression, data: ["id": id])
     }
 
-    func adDidRecordClick(_ ad: GADFullScreenPresentingAd) {
+    func adDidRecordClick(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.adClick, data: ["id": id])
     }
 
-    func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+    func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
         plugin?.notifyListeners(Events.rewardedInterstitialShowFail, data: [
             "id": id,
             "error": error.localizedDescription
         ])
     }
 
-    func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adWillPresentFullScreenContent(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.rewardedInterstitialShow, data: ["id": id])
     }
 
-    func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
         plugin?.notifyListeners(Events.rewardedInterstitialDismiss, data: ["id": id])
         rewardedInterstitialAd = nil
     }

--- a/package.json
+++ b/package.json
@@ -33,20 +33,20 @@
     "ads"
   ],
   "scripts": {
-    "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
+    "verify": "bun run verify:ios && bun run verify:android && bun run verify:web",
     "verify:ios": "xcodebuild -scheme CapgoCapacitorAdmob -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
-    "verify:web": "npm run build",
-    "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
-    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
+    "verify:web": "bun run build",
+    "lint": "bun run eslint && bun run prettier -- --check && bun run swiftlint -- lint",
+    "fmt": "bun run eslint -- --fix && bun run prettier -- --write && bun run swiftlint -- --fix --format",
     "eslint": "eslint . --ext ts",
     "prettier": "prettier-pretty-check \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api AdMobPlusPlugin --output-readme README.md --output-json dist/docs.json",
-    "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
+    "build": "bun run clean && bun run docgen && tsc && rollup -c rollup.config.mjs",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "bun run build",
     "check:wiring": "node scripts/check-capacitor-plugin-wiring.mjs"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,12 @@ AdMob.start = async () => {
   return result;
 };
 
+const adIsLoaded = AdMob.adIsLoaded.bind(AdMob);
+AdMob.adIsLoaded = (async (...args: Parameters<AdMobPlusPlugin['adIsLoaded']>) => {
+  const result = (await adIsLoaded(...args)) as boolean | { value?: boolean };
+  return typeof result === 'boolean' ? result : result.value === true;
+}) as AdMobPlusPlugin['adIsLoaded'];
+
 class MobileAd<T extends MobileAdOptions = MobileAdOptions> {
   private static allAds: { [s: number]: MobileAd } = {};
   private static idCounter = 0;
@@ -46,8 +52,7 @@ class MobileAd<T extends MobileAdOptions = MobileAdOptions> {
 
   protected async isLoaded() {
     await this.init();
-    const result = (await AdMob.adIsLoaded({ id: this.id })) as boolean | { value?: boolean };
-    return typeof result === 'boolean' ? result : Boolean(result.value);
+    return AdMob.adIsLoaded({ id: this.id });
   }
 
   protected async load() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,8 @@ class MobileAd<T extends MobileAdOptions = MobileAdOptions> {
 
   protected async isLoaded() {
     await this.init();
-    return AdMob.adIsLoaded({ id: this.id });
+    const result = (await AdMob.adIsLoaded({ id: this.id })) as boolean | { value?: boolean };
+    return typeof result === 'boolean' ? result : Boolean(result.value);
   }
 
   protected async load() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,25 @@ const AdMob = registerPlugin<AdMobPlusPlugin>('AdMobPlus', {
 let started = false;
 let startPromise: ReturnType<typeof AdMob.start> | null = null;
 
-const start = AdMob.start;
-AdMob.start = async () => {
-  startPromise = start();
-  const result = await startPromise;
-  started = true;
-  return result;
+const start = AdMob.start.bind(AdMob);
+const ensureStarted = async () => {
+  if (started) return;
+
+  if (startPromise === null) {
+    startPromise = start()
+      .then((result) => {
+        started = true;
+        return result;
+      })
+      .catch((error) => {
+        startPromise = null;
+        throw error;
+      });
+  }
+
+  return startPromise;
 };
+AdMob.start = ensureStarted as AdMobPlusPlugin['start'];
 
 const adIsLoaded = AdMob.adIsLoaded.bind(AdMob);
 AdMob.adIsLoaded = (async (...args: Parameters<AdMobPlusPlugin['adIsLoaded']>) => {
@@ -74,8 +86,7 @@ class MobileAd<T extends MobileAdOptions = MobileAdOptions> {
     if (this.#created) return;
 
     if (!started) {
-      if (startPromise === null) start();
-      await startPromise;
+      await ensureStarted();
     }
 
     if (this.#init === null) {


### PR DESCRIPTION
## What
- update the Android implementation from `play-services-ads` to the Google Mobile Ads Next Gen SDK (`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:0.25.0-beta01`)
- align the iOS dependency and bridge code with Google Mobile Ads SDK `13.1.x`
- keep the existing Capacitor-facing API stable while normalizing `adIsLoaded` responses and updating repo scripts to use `bun run`

## Why
- we want this plugin on the nextgen AdMob SDK path, using the upstream `cordova-plugin-admob-nextgen` migration as the reference point
- the native SDK changes require bridge updates on both Android and iOS before users can adopt the newer SDKs safely

## How
- port the Android bridge to nextgen request/configuration, banner/interstitial/rewarded loading, server-side verification, and initialization APIs
- add the Android API 35 `AdActivity` workaround and read the AdMob app ID from manifest metadata for nextgen initialization
- migrate the iOS bridge from the old `GAD*` Swift symbols to the current `GoogleMobileAds` 13 API surface and bump both CocoaPods and SPM dependencies
- preserve the JS API shape by tolerating either boolean or `{ value }` load-state responses and switch repo scripts from `npm run` to `bun run`

## Testing
- `bun run fmt`
- `bun run verify`

## Not Tested
- live ad serving and impression/click/reward flows on physical Android and iOS devices
- integration validation inside a host Capacitor app with production AdMob app/unit IDs

_This PR was prepared with Codex._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * iOS Google Mobile Ads pinned to 13.1.x; Android migrated to the Next Gen Mobile Ads SDK; Android plugin version bumped.

* **Documentation**
  * README updated with iOS/Android SDK compatibility and preserved Capacitor-facing API note.

* **Build & Development**
  * Developer scripts and CI switched to Bun for verify, lint, format, and build workflows; Gradle network timeout increased.

* **Bug Fixes / Behavior**
  * Safer ad lifecycle and reward handling, explicit App ID validation, improved initialization gating, and clearer failure events/messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->